### PR TITLE
Fix bug handling newlines

### DIFF
--- a/js/gedcom/parser.js
+++ b/js/gedcom/parser.js
@@ -93,7 +93,7 @@ GedcomParser.prototype = {
 	},
 
 	extract : function(line, i) {
-		var result = line.match(/(\d) ([^ ]*) ?(.*)?/);
+		var result = line.trim().match(/(\d) ([^ ]*) ?(.*)?/);
 		// Ligne non conforme
 		if (null == result) {
 			return null;


### PR DESCRIPTION
Gedcoms exported by, for example, Ancestry.com, use an incompatible line ending convention
